### PR TITLE
[Fix][v1.1.1] Unload audio on Gig.stop

### DIFF
--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -170,7 +170,7 @@ var Gig = function (_Track) {
     value: function play() {
       var _this3 = this;
 
-      this.music.once('load', function () {
+      this.music.on('load', function () {
         if (!_this3.clock) _this3.start();
 
         _this3.music.play();
@@ -188,6 +188,7 @@ var Gig = function (_Track) {
       if (!this.clock) return;
 
       this.music.stop();
+      this.music.unload();
       this.clock.stop();
       this.emit('stop');
     }
@@ -239,6 +240,7 @@ var Gig = function (_Track) {
     key: 'seek',
     value: function seek(to) {
       this.music.seek(to);
+      // TODO: this.reorient()
       this.emit('seek');
     }
 
@@ -248,7 +250,6 @@ var Gig = function (_Track) {
      * @param {Object} [context] stateful dynamic interval context
      * @returns {Object} updated interval context
      */
-    // TODO: support `bach.Set` (i.e. concurrent elements)
 
   }, {
     key: 'step',
@@ -306,6 +307,16 @@ var Gig = function (_Track) {
     value: function loading() {
       return this.music.state() === 'loading';
     }
+
+    /**
+     * Determines if the track's music is loaded
+     */
+
+  }, {
+    key: 'loaded',
+    value: function loaded() {
+      return this.music.state() === 'loaded';
+    }
   }, {
     key: 'state',
     get: function get$$1() {
@@ -349,6 +360,42 @@ var Gig = function (_Track) {
         measure: Math.min(Math.max(this.index.measure, 0), this.data.length - 1),
         beat: Math.min(Math.max(this.index.beat, 0), this.data[this.index.measure].length - 1)
       };
+    }
+
+    /**
+     * Determines how much time remains (in milliseconds) until the next tick.
+     *
+     * @returns {Number}
+     */
+
+  }, {
+    key: 'until',
+    get: function get$$1() {
+      return this.interval * (1 - this.beatAt() % 1);
+    }
+
+    /**
+     * Determines the progress of the track's audio (in milliseconds).
+     *
+     * @returns {Number}
+     */
+
+  }, {
+    key: 'progress',
+    get: function get$$1() {
+      return this.music.seek() * 1000;
+    }
+
+    /**
+     * Determines the duration of the track's audio (in milliseconds).
+     *
+     * @returns {Number}
+     */
+
+  }, {
+    key: 'duration',
+    get: function get$$1() {
+      return this.music.duration() * 1000;
     }
   }]);
   return Gig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -2422,9 +2422,9 @@
       }
     },
     "howler": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/howler/-/howler-2.1.3.tgz",
-      "integrity": "sha512-PSGbOi1EYgw80C5UQbxtJM7TmzD+giJunIMBYyH3RVzHZx2fZLYBoes0SpVVHi/SFa1GoNtgXj/j6I7NOKYBxQ=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/howler/-/howler-2.2.0.tgz",
+      "integrity": "sha512-sGPkrAQy7jh5mNDbkRNG0F82R2HFDYNsQXBcX4smXQT0y0F4UMsa/+jXaGwWvcrajWr2tDB7JUkH7G5qSnuIyQ=="
     },
     "http-errors": {
       "version": "1.7.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gig",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://github.com/slurmulon/gig#readme",
   "dependencies": {
     "bach-js": "github:slurmulon/bach-js",
-    "howler": "^2.1.3",
+    "howler": "^2.2.0",
     "stateful-dynamic-interval": "1.0.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gig",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Bach player for JS",
   "main": "dist/bundle.js",
   "scripts": {


### PR DESCRIPTION
**Changes**
 - :bug: Fixed a bug in `Gig.stop` that prevented subsequent `Gig.play` from working (audio never "loaded")
    - Issue stemmed from `howler` holding onto the audio in memory even after the `Gig` object is destroyed, which prevents `this.music.on('load')` from firing again
    - Solution is to call `music.unload()` in `Gig.stop` in _addition_ to `music.stop()` (apparently calling `stop` in `howler` does NOT unload the audio)
      * Potential performance hit here since the audio may re-fetch, but in my testing it still uses the browser's disk cache
      * Can eliminate performance hit once we integrate Workbox (can control that cache at the Service Worker level ourselves)
 - :anchor: Added some basic scaffolding work towards re-orientation / recovery
      * Unrelated to this fix - but thought it was necessary at first
      * Handle this in another branch once we move onto supporting `pause` / `resume`
 - :wrench: Upgraded `howler` to `2.2.0`
 - :shipit: Version 1.1.1